### PR TITLE
navigation: knotenkarte: direct link to meshvierwer

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -30,12 +30,15 @@
                 <li><a class="page-link" href="/unterstuetzung">Unterstützung</a></li>
               </ul>
             </li>
+            <!-- Page "Knotenkarte" is broken, disable it for now.
             <li class="dropdown">
               <a href="/knotenkarte">Knotenkarte<b class="caret"></b></a>
               <ul class="dropdown-menu">                
                 <li><a class="page-link" href="/map">Meshviewer</a></li>
               </ul>
             </li>
+            -->
+            <li><a href="/map">Knotenkarte</a></li>
             <li><a href="/faq">FAQ</a></li>
             <li><a href="/nutzungsbedingungen">Nutzungsbedingungen</a></li>
             <li><a href="/podcast">Podcast</a></li>


### PR DESCRIPTION
The "Knotenkarte" page does not provide any useful information,
as the iframe is not working.

Avoid the dropdown menu and link directly to meshviewer.