### PR TITLE
Introduce post archive

### DIFF
--- a/archiv.md
+++ b/archiv.md
@@ -1,0 +1,29 @@
+---
+layout: page
+title: Archiv
+---
+
+<div class="row">        
+    <div class="col-sm-6">
+        <div class="list-group">
+
+<div class="panel-heading" markdown="1">
+### 2014
+
+<ul class="posts">
+{% for post in site.posts %}
+  {% assign y = post.date | date: "%Y" %}
+  {% if y == "2014" %}
+  <li>
+    <span class="post-date">{{ post.date | date: "%b %-d" }}</span>
+    <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
+  </li>
+  {% endif %}
+{% endfor %}
+</ul>
+
+</div>
+
+        </div>
+    </div>
+</div>

--- a/index.md
+++ b/index.md
@@ -15,14 +15,17 @@ Unser Ziel: Der Aufbau und Betrieb eines freien und unabhängigen WLAN Netzes in
 
 <ul class="posts">
 {% for post in site.posts %}
+  {% assign y = post.date | date: "%Y" %}
+  {% if y != "2014" %}
   <li>
     <span class="post-date">{{ post.date | date: "%b %-d, %Y" }}</span>
     <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
   </li>
+  {% endif %}
 {% endfor %}
 </ul>
 
-<p class="rss-subscribe"><a href="{{ "/feed.xml" | prepend: site.baseurl }}">RSS abonnieren</a></p>
+<p class="rss-subscribe"><a href="{{ "/feed.xml" | prepend: site.baseurl }}">RSS abonnieren</a> | <a href="{{ "/archiv" | prepend: site.baseurl }}">Archiv</a></p>
 </div>
 
         </div>


### PR DESCRIPTION
Da die Startseite mit den vielen Neuigkeiten immer länger wird, ist es imo gut ältere Posts (momentan von 2014) in ein Archiv zu packen. Bei mobiler Betrachtigung kommt die Treffen Spalte erst ganz unten *scroll.scroll*.

Dieses Archiv ist unten verlinkt und die Linkkonsistenz bleibt erhalten.