### PR TITLE
Add a warning that TP-Link 841N is only supported to Version 11.0

### DIFF
--- a/mitmachen.md
+++ b/mitmachen.md
@@ -43,7 +43,7 @@ Wohnung, Geschäft, Café, Restaurant, Bar
 #### So kannst du mitmachen
 
 * Besorge einen Freifunk-fähigen 2,4&nbsp;GHz Router. Von unseren [unterstützten Modellen][firmware] empfehlen wir:
-  * TP-Link TL-WR841N (ca. 16&nbsp;€)
+  * TP-Link TL-WR841N, bis Version 11.0. Ihr könnt bei uns nachfragen, wie ihr an alte Geräte kommt. (ca. 16&nbsp;€)
   * TL-WDR4300 (ca. 45&nbsp;€)
   * Ubiquiti Enterprise AP UAP, geeignet für Restaurants (ca. 60&nbsp;€)
 * [Installiere][router-flashen] und [konfiguriere][router-konfigurieren] die Freifunk-Firmware.


### PR DESCRIPTION
Most of the catalogue companies out there send out the TP-Link 841N in version 14.0 which is not supported at the moment. That was not clear in the how to start instructions and lead to some people buying incompatible devices. I added a warning to fix this issue.