### PR TITLE
Add 'rel' link so that feedreaders can pick up the page feed

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -24,6 +24,9 @@
     <!-- Projekktor -->
     <link rel="stylesheet" href="{{ "/assets/projekktor/projekktor.style.css" | prepend: site.baseurl }}">
 
+    <!-- page feed -->
+    <link rel="alternate" type="application/rss+xml" title="Freifunk München Feed" href="/feed.xml" />
+
     <!-- podlove stuff -->
     <link rel="alternate" type="application/rss+xml" title="mp3 Podcast Feed" href="https://ffmuc.net/podcast/mp3.xml" />
 </head>


### PR DESCRIPTION
Feedreaders will only find the podcast feed, because there is no rel link defined for the main page. This pullrequest adds the rel link to /feed.xml.