### PR TITLE
Promote the use of mattermost and the ticketsystem

### DIFF
--- a/kontakt.md
+++ b/kontakt.md
@@ -6,7 +6,6 @@ permalink: /kontakt/
 
 {% include treffen.md %}
 
-E-Mail: [muenchen@freifunk.net](mailto:muenchen@freifunk.net) (Öffentliche Mailingliste!)
 
 Twitter: [@FreifunkMUC](https://twitter.com/FreifunkMUC)
 
@@ -30,6 +29,7 @@ E-Mail: [abuse@ffmuc.net](mailto:abuse@ffmuc.net)
 
 ### Mailingliste
 
+[muenchen@freifunk.net](mailto:muenchen@freifunk.net) (Öffentliche Mailingliste!)
 [Allgemeine Mailingliste Freifunk München][allgListe] \\
 [Mailingliste für EntwicklerInnen und Technikinteressierte][devListe] \\
 [Mailingliste zur Koordination von Projekten zur Unterstützung von Flüchtlingen][fluechtListe]


### PR DESCRIPTION
Due to mailinglists being a pain in the ass and sometimes turning into a complete chaos, i'd wish to place the maillinglist address a bit further down the page, promoting the use of mattermost and our ticketsystem.