### PR TITLE
Laptopspendenaktion mit der AWO und der MdB Bela Bach

### DIFF
--- a/_posts/2020-04-23-laptopsammelei.markdown
+++ b/_posts/2020-04-23-laptopsammelei.markdown
@@ -1,0 +1,19 @@
+---
+layout: post
+title:  "Laptopsammelei - Aufruf zur Laptopspende für Schüler*innen im Landkreis München"
+date:   2020-04-23 22:00:00
+categories: freifunkmuc
+---
+
+Gemeinsam mit dem AWO Kreisverband München-Land e. V. und der Bundestagsabgeordneten Bela Bach starten wir eine Hilfsaktion: Wir bitten um die Spende funktionsfähiger Laptops, die an Schüler*innen im Landkreis weitergegeben werden, die selbst über keinen Laptop verfügen.
+
+Helferinnen und Helfer von Freifunk München werden ihr Wissen einbringen, alle persönlichen Daten von den Geräten löschen und das Betriebssystem frisch aufspielen.
+
+In Frage kommen nur funktionsfähige Geräte, das heißt: 
+* Der Laptop muss funktionstüchtig und internetfähig sein
+* Das Gerät läuft mit möglichst aktuellem Betriebssystem
+* Das Ladegerät muss vorhanden sein.
+
+Alle Bürgerinnen und Bürger sowie an Firmen im Landkreis München, die einen geeigneten Laptop besitzen, bitten wir sich bei bela.bach.wk@bundestag.de zu melden.
+
+Abgegeben werden können die Laptops entweder persönlich zu den entsprechenden Öffnungszeiten in den [Klawotten im Landkreis München](https://awo-kvmucl.de/klawotte-2/) sowie bei der AWO Kinderkrippe Feldmäuse (Bahnhofstraße 8, 85622 Feldkirchen), Montag bis Freitag von 8:00 Uhr bis 15:00 Uhr (Betretungsverbot, Abgabe nur direkt an der Türe möglich.) oder durch Zusendung per Post an AWO, Balanstr. 55, 81541 München.


### PR DESCRIPTION
Siehe auch: https://www.sueddeutsche.de/muenchen/landkreismuenchen/landkreis-muenchen-bela-bach-cornavirus-spenden-1.4887893