### PR TITLE
add group as codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @awlx @goligo @krombel @ce-4 @wolli80 @goliathlabs
+* @awlx @goligo @krombel @freifunkMUC/webseite


### PR DESCRIPTION
maybe it is better to add the team(webseite) than each individually?

- added webseite as codeowner
- removed redundant owners