### PR TITLE
Update Shop URL

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -32,7 +32,7 @@
         <li><a href="https://ffmuc.net/wiki/doku.php?id=knb:faq">FAQ</a></li>
         <li><a href="/nutzungsbedingungen">Nutzungsbedingungen</a></li>
         <li><a href="/wiki">Wiki</a></li>
-        <li><a href="https://shop.spreadshirt.de/freifunk-muenchen">Shop</a></li>
+        <li><a href="https://freifunk-muenchen.myspreadshop.de">Shop</a></li>
         <li class="dropdown">
           <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Dienste <span class="caret"></span></a>
           <ul class="dropdown-menu">


### PR DESCRIPTION
https://www.spreadshop.com/de/blog/2021/08/03/social-commerce-starte-durch-mit-neuer-shop-domain/

old URL: https://shop.spreadshirt.de/freifunk-muenchen
new URL: https://freifunk-muenchen.myspreadshop.de