### PR TITLE
Removed: Obsolete NanoStations

### DIFF
--- a/mitmachen.md
+++ b/mitmachen.md
@@ -73,7 +73,6 @@ Balkon, hohes Gebäude, öffentlicher Platz, Park, weitläufiges Gelände
 
 * Besorge dir einen Freifunk-fähigen 2,4&nbsp;GHz oder 5GHz Outdoor-Router. Bitte beim Kauf immer auf die Hardwareversion achten! Von unseren [unterstützten Modellen][firmware] empfehlen wir:
   * Ubiquiti UAP-AC-Mesh
-  * Ubiquiti NanoStation M2 oder M2 loco
 * [installiere][router-flashen] und [konfiguriere][router-konfigurieren] die Freifunk-Firmware.
 * Montiere den Router an einem geeigneten Ort.
 </div>


### PR DESCRIPTION
I have removed the nanostations as they will be obsolete in the near future and we probably should not be giving advice on Gluon-enabled outdoor nodes.


Closes https://github.com/freifunkMUC/freifunkmuc.github.io/issues/316