### PR TITLE
Updated: Recommended devices

### DIFF
--- a/_posts/2019-07-11-austausch-aelterer-geraete.markdown
+++ b/_posts/2019-07-11-austausch-aelterer-geraete.markdown
@@ -17,10 +17,14 @@ Wir werden versuchen so lange wie **möglich** und **sinnvoll** noch Updates fü
 
 Deswegen wollen wir euch bitten, so bald wie möglich eure alten Geräte durch neuere zu ersetzen!
 
+## Router kaufen
+
+Wir empfehlen den Besuch beim lokalen Händler deines Vertrauens, da du dort die Revision vor dem Kauf überprüfen kannst. Alternativ lohnt sich der Preisvergleich im Internet bei Seiten wie [Geizhals](https://geizhals.de/) oder [Idealo](https://www.idealo.de/). 
+
 Kostengünstige Geräte:
 
-* Xiaomi Mi Router 4C (ca. 12€) 
-* Xiaomi Mi Router 4A (ca. 25€) 
+* AVM FRITZ!WLAN Repeater 300E (max. 15€)
+* AVM FRITZ!WLAN Repeater 450E (max. 25€)
 * Gl.iNet MT300 (ca. 25€)
 * Gl.iNet AR150 (ca. 25€)
 * Gl.iNet AR300 (ca. 30€)
@@ -29,16 +33,18 @@ Mittleres Preissegment:
 
 * AVM FRITZ!Box 4020 (ca. 40€)
 * Netgear R6120 (ca. 40€)
-* Netgear EX6150V2 (ca. 50€)
 * Xiaomi Mi Router 4A Gigabit Edition (ca. 50€) 
+* AVM FRITZ!Repeater 1200 (ca. 55€)
 
 Oberes Preissegment:
 
-* AVM FRITZ!Box 4040 (ca. 70€)
-* Ubiquiti Unifi AC Lite (ca. 75€)
-* Gl.iNet GL-B1300 (ca. 80€)
-* Ubiquiti Unifi AC Mesh (ca. 85€)
+* AVM FRITZ!Box 4040 (ca. 72€)
+* Ubiquiti Unifi AC Lite (ca. 78€)
+* Gl.iNet GL-B1300 (ca. 89€)
 
+Outdoor:
+* Ubiquiti UniFi AC Mesh (ca. 87€)
+* 
 Auch schauen wir, dass wir in unserem [Marktplatz](https://ffmuc.net/pad/p/Marktplatz) einige Geräte zur Aufrüstung zur Verfügung stellen können, hierfür achten wir immer wieder auf gute Angebote und stellen diese dann kostenneutral und fertig mit FFMUC Firmware bestückt zur Verfügung.
 
 Für Fragen und Feedback könnt ihr euch gerne mit uns in [Verbindung](https://ffmuc.net/kontakt) setzen.


### PR DESCRIPTION
I updated the recommended devices. The Xiaomi Mi Router is currently not recommended as a new version is being shipped with incompatible flash and no OpenWrt support just yet. I followed the recommendations of [Freifunk Darmstadt](https://darmstadt.freifunk.net/mitmachen/unterstuetzte-geraete/)