### PR TITLE
eol-8/64: update list of devices

### DIFF
--- a/_posts/2023-12-08-supportende-von-8-64-routern.markdown
+++ b/_posts/2023-12-08-supportende-von-8-64-routern.markdown
@@ -68,15 +68,18 @@ Für Fragen und Feedback könnt ihr euch gerne mit uns in [Verbindung](https://f
 
 Liste wird regelmäßig aktualisiert.
 
+* AVM
+  * FRITZ!WLAN Repeater 1750E (RAM limitiert)
+
 * TP-Link
   * Archer C2
   * Archer C20
   * Archer C20i
   * Archer C25
   * Archer C50
+  * Archer C58 (RAM limitiert)
   * Archer C6
   * Archer C60
-  * Archer C7
   * CPE210
   * CPE510
   * TL-WR902AC


### PR DESCRIPTION
- the Archer C7 v1 is not supported by gluon
- added devices with ath10k memory and 64MB RAM