### PR TITLE
Replace height with max-height

### DIFF
--- a/_posts/2020-11-16-neues-rechenzentrum.markdown
+++ b/_posts/2020-11-16-neues-rechenzentrum.markdown
@@ -18,7 +18,7 @@ Unser neues Setup besteht aus zwei HP Servern mit je 128GB RAM, 2x 1TB SSD, 32 C
 
 Durch unser eigenes ASN mit eigenen IP Addressbereichen ist es nun möglich standortunabhängiger zu agieren.  Wir haben so die Grundlage geschaffen um auf Dauer mehr Kapazitäten in verschiedenen Städten auszubauen und mehr Dezenztralität zu erreichen.
 
-![ISP as212567](/assets/rz/isp-as212567.png){: height="400px" }
+![ISP as212567](/assets/rz/isp-as212567.png){: style="max-height: 400px;"}
 
 **Ihr wollt uns unterstützen?**
 

--- a/_posts/2020-12-12-weihnachtsaktion.markdown
+++ b/_posts/2020-12-12-weihnachtsaktion.markdown
@@ -25,4 +25,4 @@ Kreissparkasse München - Starnberg - Ebersberg<br />
 **Paypal:**<br />
 [paypal.me/ffmucspenden](https://paypal.me/ffmucspenden)
 
-![Netgear R6120](/assets/posts/2020-12-12-router.jpg){: height="400px" }
+![Netgear R6120](/assets/posts/2020-12-12-router.jpg){: style="max-height: 400px;"}

--- a/_posts/2022-02-27-richtfunk-heimstettner-see.markdown
+++ b/_posts/2022-02-27-richtfunk-heimstettner-see.markdown
@@ -13,11 +13,11 @@ Wir haben uns bei der Technik dazu entschieden nur 60 Ghz Geräte zu nutzen, um 
 
 Der Aufbau ist unterteilt in insgesamt 3 Einzelstrecken. Einmal werden Mikrotik Cube 60 eingesetzt um die kurze Strecke von der Wasserwacht auf das Silo Dach zu überbrücken. Als nächstes erfolgt die Übertragung per Ubiquiti Airfiber 60 LR zu einem weiteren Hop. Die letzte Strecke wird dann mit Hilfe von Mikrotik 60 LHG zum eigentlichen Uplink überbrückt.
 
-![Richtfunk strecken lhg60](/assets/posts/2022-02-27-lhg60.jpg){: height="400px" }
+![Richtfunk strecken lhg60](/assets/posts/2022-02-27-lhg60.jpg){: style="max-height: 400px;"}
 
-![Richtfunk strecken Airfiber](/assets/posts/2022-02-27-see-airfiber.jpg){: height="400px" }
+![Richtfunk strecken Airfiber](/assets/posts/2022-02-27-see-airfiber.jpg){: style="max-height: 400px;"}
 
-![Richtfunk strecken Cube60](/assets/posts/2022-02-27-see-cube60.jpg){: height="400px" }
+![Richtfunk strecken Cube60](/assets/posts/2022-02-27-see-cube60.jpg){: style="max-height: 400px;"}
 
 ### Geschwindigkeit
 
@@ -27,9 +27,9 @@ Wir bekommen auf der kompletten Strecke einen Durchsatz von 1Gbit/s ohne Problem
 
 Wir haben sehr wenige Probleme durch Wettereinflüsse, nur bei absolutem Starkregen kommt es zu kurzen Abbrüchen.
 
-![Richtfunk strecke im Regen](/assets/posts/2022-02-27-see-regen-rifu.jpg){: height="400px" }
+![Richtfunk strecke im Regen](/assets/posts/2022-02-27-see-regen-rifu.jpg){: style="max-height: 400px;"}
 
-![Richtfunk strecke im Regenradar](/assets/posts/2022-02-27-see-regen.jpg){: height="400px" }
+![Richtfunk strecke im Regenradar](/assets/posts/2022-02-27-see-regen.jpg){: style="max-height: 400px;"}
 
 
 ### Verwendete Hardware
@@ -38,7 +38,7 @@ Wir haben sehr wenige Probleme durch Wettereinflüsse, nur bei absolutem Starkre
 
 Wir haben uns an dieser Stelle auf Grund der Zukunftssicherheit für Mikrotik CCR2004-1G-12S+2XS entschieden. Dieser verfügt über 12 x 10G SFP+ und 2 x 25G SFP28 ports. Im Moment betreiben wir ihn mit Kupfer SFPs von Flexoptix.
 
-![Router](/assets/posts/2022-02-27-see-router.jpeg){: height="400px" }
+![Router](/assets/posts/2022-02-27-see-router.jpeg){: style="max-height: 400px;"}
 
 Als kleiner Switch der Routingfähig ist, falls es mal gebraucht wird setzen wir den Mikrotik CRS305-1G-4S+IN ein. Auch hier verwenden wir im Moment Kupfer SFPs von Flextopix.
 
@@ -56,7 +56,7 @@ Wie oben bereits geschrieben, kommen hier verschiedene Produkte je nach Entfernu
 
 Um an der Wasserwacht das Netz ausstrahlen zu können setzen wir auf Ubiquiti Unifi UAP-Mesh. Für die Außensektoren sind diese zusätzlich mit UMA-D Antennen ausgestattet.
 
-![Accesspoints](/assets/posts/2022-02-27-see-unifi-ap.jpg){: height="400px" }
+![Accesspoints](/assets/posts/2022-02-27-see-unifi-ap.jpg){: style="max-height: 400px;"}
 
 ### Wie geht es weiter?
 

--- a/_posts/2022-03-14-ukraine-unterstuetzung.markdown
+++ b/_posts/2022-03-14-ukraine-unterstuetzung.markdown
@@ -13,21 +13,21 @@ Dem [GOROD Kulturzentrum](https://de.newgorod.org) haben wir sehr kurzfristig mi
 Hier werden derzeit circa 230 gleichzeitig verbundene Clients mit etwa 1 TB Traffic täglich versorgt. Man sieht deutlich, wie sehr die Menschen auf Internet angewiesen sind.
 
 
-![Switch](/assets/posts/2022-03-14-gorod.png){: height="400px" }
+![Switch](/assets/posts/2022-03-14-gorod.png){: style="max-height: 400px;"}
 ### Einrichtung AWO-Unterkunft Neuherbergstraße
 
 Auch in der [Aufnahmestelle Neuherbergstraße](https://map.ffmuc.net/#!/de/map/6aaa521e6bc0) stellen wir aktuell den Geflüchteten einen Internetzugang bereit - für über 120 Endgeräte. Hier ist der Uplink über LTE realisiert, da vor Ort kein vorhandener Anschluss geschaltet ist.
 
-![Hardware](/assets/posts/2022-03-14-awo-01.jpg){: height="400px" }
-![Aufbau](/assets/posts/2022-03-14-awo-02.jpg){: height="400px" }
+![Hardware](/assets/posts/2022-03-14-awo-01.jpg){: style="max-height: 400px;"}
+![Aufbau](/assets/posts/2022-03-14-awo-02.jpg){: style="max-height: 400px;"}
 
 # Wie geht es weiter?
 
 Da soll jedoch nicht Schluss sein. Wir haben bereits neue Hardware bestellt, in der Hoffnung vielen weiteren Menschen zumindest eine Grundversorgung mit Internet anbieten zu können. Falls Ihr also Kontakte habt oder selber Hilfe bei der Versorgung von Unterkünften braucht, dann [kontaktiert](https://chat.ffmuc.net/freifunk/channels/ukraine-hilfe---2022) uns einfach. Wir helfen gerne!
 
-![TP-Link](/assets/posts/2022-03-14-tplink.jpg){: height="400px" }
-![UniFi](/assets/posts/2022-03-14-unifi.jpg){: height="400px" }
-![Mikrotik](/assets/posts/2022-03-14-mikrotik.jpg){: height="400px" }
+![TP-Link](/assets/posts/2022-03-14-tplink.jpg){: style="max-height: 400px;"}
+![UniFi](/assets/posts/2022-03-14-unifi.jpg){: style="max-height: 400px;"}
+![Mikrotik](/assets/posts/2022-03-14-mikrotik.jpg){: style="max-height: 400px;"}
 
 
 ### Kontaktmöglichkeiten

--- a/_posts/2022-04-21-ukraine-unterstuetzung-teil2.markdown
+++ b/_posts/2022-04-21-ukraine-unterstuetzung-teil2.markdown
@@ -28,7 +28,7 @@ https://ffmuc.net/freifunkmuc/2022/03/25/internet-fuer-fluechtlinge/
 
 Impressionen der Aufbauten:
 
-|![Aufbau UHG](/assets/posts/2022-04-21-UHG.jpeg){: height="400px" }|![Aufbau UHG2](/assets/posts/2022-04-21-UHG2.jpeg){: height="400px" }|
-|![Auto](/assets/posts/2022-04-21-auto.jpeg){: height="400px" }|![Aufbau AWO](/assets/posts/2022-04-21-AWO.jpg){: height="400px" }|
-|![LTE](/assets/posts/2022-04-21-lte-notversorgung.jpeg){: height="400px" }|![Aufbau AWO](/assets/posts/2022-04-21-rz-upgrade.jpeg){: height="400px" }|
+|![Aufbau UHG](/assets/posts/2022-04-21-UHG.jpeg){: style="max-height: 400px;"}|![Aufbau UHG2](/assets/posts/2022-04-21-UHG2.jpeg){: style="max-height: 400px;"}|
+|![Auto](/assets/posts/2022-04-21-auto.jpeg){: style="max-height: 400px;"}|![Aufbau AWO](/assets/posts/2022-04-21-AWO.jpg){: style="max-height: 400px;"}|
+|![LTE](/assets/posts/2022-04-21-lte-notversorgung.jpeg){: style="max-height: 400px;"}|![Aufbau AWO](/assets/posts/2022-04-21-rz-upgrade.jpeg){: style="max-height: 400px;"}|
 

--- a/_posts/2024-02-27-wartungsarbeiten-neue-server-muc.markdown
+++ b/_posts/2024-02-27-wartungsarbeiten-neue-server-muc.markdown
@@ -18,7 +18,7 @@ Bitte beachten Sie die folgenden Details:
 
 Wir entschuldigen uns für eventuelle Unannehmlichkeiten, die Ihnen während dieser Zeit entstehen. Die Wartung ist notwendig, um die Leistung und Zuverlässigkeit unserer Dienste zu verbessern.
 
-|![Neue Server 1](/assets/posts/2024-02-27-upgrade1.jpeg){: height="400px" }|![Neue Server 2](/assets/posts/2024-02-27-upgrade2.jpeg){: height="400px" }|![Neue Server 3](/assets/posts/2024-02-27-upgrade3.jpeg){: height="400px" }
+![Neue Server 1](/assets/posts/2024-02-27-upgrade1.jpeg){: style="max-height:400px;"} | ![Neue Server 2](/assets/posts/2024-02-27-upgrade2.jpeg){: style="max-height:400px;"} | ![Neue Server 3](/assets/posts/2024-02-27-upgrade3.jpeg){: style="max-height:400px;"}
 
 Bitte beachten Sie, dass es sich hierbei um eine vorläufige Ankündigung handelt und Änderungen vorbehalten sind. 
 

--- a/css/main.css
+++ b/css/main.css
@@ -113,7 +113,6 @@ a:visited { color: #205caa; }
 }
 
 .page-content img {
-  max-width: 60%;
   text-align: center;
 }
 


### PR DESCRIPTION
Currently, we are using "max-width: 90%;" as part of .post-content img that forces a maximum width. Together with a hardcoded height, this can lead to distorted images.
When setting max-height instead of height on an image, either of the two max settings will take precedence over the other and scale the image while keeping the aspect ratio fixed.