### PR TITLE
Update deploy.yml only run if freifunkmuc is owner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   deploy:
+    if: github.repository_owner == 'freifunkMUC'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Update deploy.yml only run if freifunkmuc is owner  (Fix failing Github Action)

failing:
https://github.com/T0biii/freifunkmuc.github.io/actions/runs/8295809790/job/22703618753
skipped:
https://github.com/T0biii/freifunkmuc.github.io/actions/runs/8295897981