### PR TITLE
add news to Firmware Rollout v2024.4.2+v2022.5.7

### DIFF
--- a/_posts/2024-04-30-firmware-update.markdown
+++ b/_posts/2024-04-30-firmware-update.markdown
@@ -1,0 +1,20 @@
+---
+layout: posts
+title:  "Firmware Rollout auf v2024.4.2 - Ulm Integration"
+date:   2024-04-30 10:00:00
+categories: freifunkmuc
+---
+ 
+Der Monat April neigt sich dem Ende zu und wir waren wieder fleißig.  
+Momentan befindet sich die Version **v2024.4.2** für stable sowie **v2022.5.7** für Legacy Geräte im Rollout.
+
+In den beiden Versionen ist alles vorbereitet für die Migration von [Freifunk Ulm](https://wiki.freifunk-ulm.de/) in unsere Firmware.  
+Mehr Infos und bei generellen Fragen zu Freifunk Ulm meldet euch gerne bei uns im [Chat](https://chat.ffmuc.net/freifunk/channels/freifunk-ulm).
+
+## Changelogs:
+### Stable:
+- [v2024.4.2](https://github.com/freifunkMUC/site-ffm/releases/tag/v2024.4.2) (Rename Ulm Domain)
+- [v2024.4.1](https://github.com/freifunkMUC/site-ffm/releases/tag/v2024.4.1) (add Ulm Domain)
+- [v2024.3.1](https://github.com/freifunkMUC/site-ffm/releases/tag/v2024.3.2) (User Agent für Broker call)
+### Legacy:  
+- [v2022.5.7](https://github.com/freifunkMUC/site-ffm/releases/tag/v2022.5.7) (Migrationspackage für Ulm + ein paar Backports) 

--- a/_posts/2024-04-30-firmware-update.markdown
+++ b/_posts/2024-04-30-firmware-update.markdown
@@ -15,6 +15,6 @@ Mehr Infos und bei generellen Fragen zu Freifunk Ulm meldet euch gerne bei uns i
 ### Stable:
 - [v2024.4.2](https://github.com/freifunkMUC/site-ffm/releases/tag/v2024.4.2) (Rename Ulm Domain)
 - [v2024.4.1](https://github.com/freifunkMUC/site-ffm/releases/tag/v2024.4.1) (add Ulm Domain)
-- [v2024.3.1](https://github.com/freifunkMUC/site-ffm/releases/tag/v2024.3.2) (User Agent für Broker call)
+- [v2024.3.1](https://github.com/freifunkMUC/site-ffm/releases/tag/v2024.3.2) (User Agent für Broker call)  
 ### Legacy:  
 - [v2022.5.7](https://github.com/freifunkMUC/site-ffm/releases/tag/v2022.5.7) (Migrationspackage für Ulm + ein paar Backports) 


### PR DESCRIPTION

![image](https://github.com/freifunkMUC/freifunkmuc.github.io/assets/5702338/7668fad6-57b4-42db-8877-7cd006b4e477)

ggf. muss die Uhrzeit noch geändert werden damit die Seite generiert wird oder man wartet noch mit dem merge