### PR TITLE
Update 2023-12-08-supportende-von-8-64-routern.markdown, Empfehlung zu ipq40xx und mt7621 Geräten statt dem buggy mt-filogic

### DIFF
--- a/_posts/2023-12-08-supportende-von-8-64-routern.markdown
+++ b/_posts/2023-12-08-supportende-von-8-64-routern.markdown
@@ -36,10 +36,11 @@ Hier findet ihr außerdem eine [Geschwindigkeitsmessungen für viele Geräte](ht
 
 Siehe [Empfehlungen von Freifunk Aachen](https://wiki.freifunk.net/Freifunk_Aachen/Hardware)
 
-Neu im nächsten Release (v2024+)
-* Zyxel Multy M1 (ca 35€)
-* Cudy WR3000 (ca 55€)
-* Netgear WAX220 (ca. 130€)
+Besonders empfehlen wir:
+* D-Link DAP-X1860 (ca. 30&nbsp;€, Wifi 6, Steckdosenplug)
+* AVM Fritzbox 7520 (ca. 30&nbsp;€ gebraucht, Wifi 4&5)
+* D-Link COVR-X1860 (ca. 50&nbsp;€, Wifi 6)
+* ZyXEL WSM20/Multy-M1 (ca. 50&nbsp;€, Wifi 6, inkl. Wandhalterung)
 
 
 ### High-Performance Lösungen:


### PR DESCRIPTION
Statt "neu" lieber "besonders empfohlen", da ich gerade nicht weiß aus welcher Firmware die Geräte sind. Da WAX220 und cudy wr3000 noch Probleme haben, wurden sie rausgenommen, und stattdessen COVR, DAP, WSM20 und 7520 empfohlen.