### PR TITLE
exclude CNAME and CODEOWNERS

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -106,6 +106,8 @@ exclude:
   - package-lock.json
   - Rakefile
   - README
+  - CNAME
+  - CODEOWNERS
   - tmp
   - /docs # ignore Minimal Mistakes /docs
   - /test # ignore Minimal Mistakes /test


### PR DESCRIPTION
Fügt CNAME und CODEOWNERS zu den excludes hinzu
momentan kann man noch über z.b. https://ffmuc.net/CNAME diese Infos runterladen werden aber nicht benötigt